### PR TITLE
Update model interface return types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Cargo.lock
+target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modellib"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Replaces `bool` returns for the model interface with `ConfigStatus` and `RuntimeStatus`

- Both enums have `OK` and `ERROR`
- ConfigStatus has `INTERFACECHANGED`
   - This is meant to support future work where models can change their interface during the config stage of the sim