### PR TITLE
Bring interface to step call, add time to interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "modellib"
+name = "rsisappinterface"
 version = "0.1.1"
 edition = "2021"
 

--- a/src/framework.rs
+++ b/src/framework.rs
@@ -13,6 +13,8 @@ pub trait ChannelTx {
 }
 
 pub trait Framework : Send {
+    fn get_simtick(&self) -> i64;
+    fn get_simtime(&self) -> f64;
     fn request_rx(&mut self, id : i64) -> Option<Box<dyn ChannelRx>>;
     fn request_tx(&mut self, id : i64) -> Box<dyn ChannelTx>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub type SizeCallback = unsafe extern "C" fn(size : usize) -> *mut u8;
 pub trait BaseModel {
     fn config(&mut self) -> ConfigStatus;
     fn init(&mut self, interface : &mut Box<dyn Framework>) -> RuntimeStatus;
-    fn step(&mut self) -> RuntimeStatus;
+    fn step(&mut self, interface : &mut Box<dyn Framework>) -> RuntimeStatus;
     fn pause(&mut self) -> RuntimeStatus;
     fn stop(&mut self) -> RuntimeStatus;
 
@@ -64,7 +64,7 @@ impl BaseModel for BaseModelExternal {
     fn init(&mut self, _interface : &mut Box<dyn Framework>) -> RuntimeStatus {
         unsafe { (self.init_fn)(self.obj) }
     }
-    fn step(&mut self) -> RuntimeStatus {
+    fn step(&mut self, _interface : &mut Box<dyn Framework>) -> RuntimeStatus {
         unsafe { (self.step_fn)(self.obj) }
     }
     fn pause(&mut self) -> RuntimeStatus {


### PR DESCRIPTION
- Adds interface to the `step` function
- Adds `get_simtime` and `get_simtick` to the interface for time in floating point and integer formats
- Changes name of package from `modellib` to `rsisappinterface`