### PR TITLE
Added new status to RuntimeStatus for ending a sim

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsisappinterface"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub enum ConfigStatus {
 pub enum RuntimeStatus {
     OK,
     ERROR,
+    FINISHED,
 }
 
 pub type ConfigStatusCallback  = unsafe extern "C" fn(obj : *mut c_void) -> ConfigStatus;


### PR DESCRIPTION
This new status is meant to indicate that an app has finished and can no longer continue to execute